### PR TITLE
add enum by json

### DIFF
--- a/src/main/java/com/echitgar/schema/interfaces/EnumInterface.java
+++ b/src/main/java/com/echitgar/schema/interfaces/EnumInterface.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2022 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.echitgar.schema.interfaces;
+
+public interface EnumInterface {
+  String value();
+}

--- a/src/main/resources/json/schema/enums/direction.json
+++ b/src/main/resources/json/schema/enums/direction.json
@@ -1,0 +1,35 @@
+{
+  "$id": "json/schema/enums/direction.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Compass direction",
+  "description": "Compass direction",
+  "definitions": {
+    "direction": {
+      "javaType": "com.echitgar.json.schema.enums.Direction",
+      "description": "One of compass directions",
+      "type": "string",
+      "javaInterfaces": ["com.echitgar.schema.interfaces.EnumInterface"],
+      "enum": [
+        "North",
+        "South",
+        "East",
+        "West"
+      ],
+      "javaEnums": [
+        {
+          "name": "North"
+        },
+        {
+          "name": "South"
+        },
+        {
+          "name": "East"
+        },
+        {
+          "name": "West"
+        }
+      ],
+      "default": "North"
+    }
+  }
+}

--- a/src/main/resources/json/schema/enums/weekDays.json
+++ b/src/main/resources/json/schema/enums/weekDays.json
@@ -1,0 +1,15 @@
+{
+  "$id": "json/schema/enums/weekDays.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Day of weeks",
+  "description": "This schema defines the day of weeks",
+  "definitions": {
+    "day": {
+      "javaType": "com.echitgar.json.schema.enums.WeekDays",
+      "description": "Day of weeks",
+      "type": "string",
+      "enum": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+      "default": "Sunday"
+    }
+  }
+}


### PR DESCRIPTION
add enum classes in two different ways. Weekdays.java is created by just one class but Direction.java is declared via EnumInterface.java